### PR TITLE
Split PlaceholderImage off from HeroImage

### DIFF
--- a/frontend/src/components/HeroImage.astro
+++ b/frontend/src/components/HeroImage.astro
@@ -1,9 +1,10 @@
 ---
 import {lorem} from '../placeholder';
+import PlaceholderImage from './PlaceholderImage.astro';
 ---
 
 <div class="relative">
-    <img src="image-placeholder.png" class="w-[100%] h-[400px] border-4 border-black my-4"/>
+    <PlaceholderImage width="100%" height="400px" />
     <section class="absolute w-[400px] h-fit m-5 top-1/4 right-10 bg-white p-2 border-2 border-black">
         {lorem.generateSentences(3)}
     </section>

--- a/frontend/src/components/PlaceholderImage.astro
+++ b/frontend/src/components/PlaceholderImage.astro
@@ -1,0 +1,9 @@
+---
+interface Props {
+  width: string,
+  height: string,
+}
+
+const {width, height} = Astro.props;
+---
+<img src="image-placeholder.png" class=`border-4 border-black my-4` style=`width: ${width}; height: ${height}` />

--- a/frontend/src/pages/events.astro
+++ b/frontend/src/pages/events.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import HeroImage from "../components/HeroImage.astro";
+import PlaceholderImage from "../components/PlaceholderImage.astro";
 import { lorem } from "../placeholder";
 ---
 
@@ -12,7 +12,7 @@ import { lorem } from "../placeholder";
     <br />
     <p>{lorem.generateParagraphs(1)}</p>
   </section>
-  <HeroImage />
+  <PlaceholderImage width="100%" height="400px" />
   <div class="border-2 border-black mt-2 p-2">
     <h2 class="text-lg font-bold">Event Title 1</h2>
     <p class="font-bold">March 21, 2023 - 8:00pm</p>


### PR DESCRIPTION
The term ["hero image"](https://www.optimizely.com/optimization-glossary/hero-image/) seems to refer to a large image specifically on the home page.

Since we'll want to include placeholder images elsewhere in the site, I've created a dedicated `PlaceholderImage` component, and gave it `width` and `height` props so that we can have different sizes of images in different parts of the site.

The `HeroImage` component now imports the `PlaceholderImage` and adds the floating text box.

I've also switched the `HeroImage` to a `PlaceholderImage` on the events page.