### PR TITLE
Read frontend runtime env variables from .env using dotenv

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -2,6 +2,8 @@ import { defineConfig } from 'astro/config';
 import tailwind from "@astrojs/tailwind";
 
 import node from "@astrojs/node";
+import * as dotenv from 'dotenv';
+dotenv.config()
 
 // https://astro.build/config
 export default defineConfig({

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@types/escape-html": "^1.0.2",
         "@types/qs": "^6.9.7",
+        "dotenv": "^16.0.3",
         "escape-html": "^1.0.3",
         "slate": "^0.82.1"
       }
@@ -1994,6 +1995,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dset": {
       "version": "3.1.2",
@@ -7121,6 +7131,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true
     },
     "dset": {
       "version": "3.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/escape-html": "^1.0.2",
     "@types/qs": "^6.9.7",
+    "dotenv": "^16.0.3",
     "escape-html": "^1.0.3",
     "slate": "^0.82.1"
   }


### PR DESCRIPTION
This is a better solution than the hack @hdsteineke and I came up with earlier today, since it reads all variables from .env, rather than having to specify them by hand in the dev script definition in package.json.